### PR TITLE
chore: bump Compose version and adding support for macos target

### DIFF
--- a/framework/compose/kodein-di-framework-compose/build.gradle.kts
+++ b/framework/compose/kodein-di-framework-compose/build.gradle.kts
@@ -26,6 +26,7 @@ kodein {
         // iosX32 not supported by jetbrains compose
         add(kodeinTargets.native.iosX64)
         add(kodeinTargets.native.iosArm64)
+        add(kodeinTargets.native.iosSimulatorArm64)
 
         add(kodeinTargets.native.macosX64)
         add(kodeinTargets.native.macosArm64)

--- a/framework/compose/kodein-di-framework-compose/build.gradle.kts
+++ b/framework/compose/kodein-di-framework-compose/build.gradle.kts
@@ -26,6 +26,9 @@ kodein {
         // iosX32 not supported by jetbrains compose
         add(kodeinTargets.native.iosX64)
         add(kodeinTargets.native.iosArm64)
+
+        add(kodeinTargets.native.macosX64)
+        add(kodeinTargets.native.macosArm64)
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ androidx-appcompat-version = "1.5.1"
 androidx-fragment-version = "1.5.4"
 androidx-lifecycle-version = "2.5.1"
 # Compose
-compose-version = "1.3.0-rc02"
+compose-version = "1.3.1"
 # KSP
 kotlinpoet-version = "1.12.0"
 ksp-version = "1.8.0-1.0.8"


### PR DESCRIPTION
Compose multiplatform also has target for MacOS. This PR add the macos target for publication.
Also adds missing ios target: `iosSimulatorArm64`